### PR TITLE
Fix network thumbnailing via playlist workaround

### DIFF
--- a/src/thumbnailer_shared.lua
+++ b/src/thumbnailer_shared.lua
@@ -327,6 +327,7 @@ function Thumbnailer:prepare_source_path()
         -- This skips ytdl on the sub-calls, making the thumbnailing faster
         -- Works well on YouTube, rest not really tested
         file_path = mp.get_property_native("stream-path")
+        file_path = file_path:gsub(",ytdl_description.+", "")
 
         -- edl:// urls can get LONG. In which case, save the path (URL)
         -- to a temporary file and use that instead.


### PR DESCRIPTION
Network thumbnailing regularly fails when it needs to use the mpv playlist
edl:// workaround. This commits adds a workaround for this, though it's a
bit of a hack:

The url added to the playlist contains a bunch of fields like `ytdl_description`
that are not actually needed. Those will break the playlist if they contain
newlines (which is common in youtube video descriptions, for example), or if
they contain urls (the urls get picked up for some reason...).

I don't know how those url are actually constructed and if it's possible
to just have some fields omitted, but here we just remove the
`ytdl_description` and everything that follows, and after a few days
of testing it seems to consistently work.

---

See #8.

That's probably not the cleanest way to do this, but it works.