### PR TITLE
Add hwdec option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ remote_max_delta=120
 # Much faster than passing the url to ytdl again, but may cause problems with some sites
 # Defaults to yes
 remote_direct_stream=[yes/no]
+
+# Parameter that mpv should use for hardware decoding
+# If properly configured can really improve thumbnail generation speed and cpu load
+# Default to no, see [mpv's manual](https://mpv.io/manual/master/#options-hwdec) for the values
+mpv_hwdec=no
 ```
 (see [`src/options.lua`](/src/options.lua) for all possible options)
 

--- a/src/options.lua
+++ b/src/options.lua
@@ -33,6 +33,8 @@ local thumbnailer_options = {
     -- Add a "--profile=<mpv_profile>" to the mpv sub-call arguments
     -- Use "" to disable
     mpv_profile = "",
+    -- Hardware decoding
+    mpv_hwdec = "no",
     -- Output debug logs to <thumbnail_path>.log, ala <cache_directory>/<video_filename>/000000.bgra.log
     -- The logs are removed after successful encodes, unless you set mpv_keep_logs below
     mpv_logs = true,

--- a/src/thumbnailer_server.lua
+++ b/src/thumbnailer_server.lua
@@ -38,8 +38,8 @@ function create_thumbnail_mpv(file_path, timestamp, size, output_path, options)
         -- Pass User-Agent and Referer - should do no harm even with ytdl active
         "--user-agent=" .. mp.get_property_native("user-agent"),
         "--referrer=" .. mp.get_property_native("referrer"),
-        -- Disable hardware decoding
-        "--hwdec=no",
+        -- User set hardware decoding
+        "--hwdec=" .. thumbnailer_options.mpv_hwdec,
 
         -- Insert --no-config, --profile=... and --log-file if enabled
         (thumbnailer_options.mpv_no_config and "--no-config" or nil),


### PR DESCRIPTION
This adds the option for the user to choose a value for the `--hwdec=` parameter for mpv subcalls.

The default is kept "no", as it currently is.

From my testing, it can be enabled without issues because mpv is able to gracefully fall back to software decoding.

I personally set it to `auto-safe`, and it almost halves the time to generate the thumbnails (of course, for encoders supported by my processor).