### PR TITLE
Support for YT storyboard

### DIFF
--- a/src/options.lua
+++ b/src/options.lua
@@ -118,6 +118,9 @@ local thumbnailer_options = {
     -- Try to grab the raw stream and disable ytdl for the mpv subcalls
     -- Much faster than passing the url to ytdl again, but may cause problems with some sites
     remote_direct_stream = true,
+
+    -- Enable storyboards (requires yt-dlp in PATH). Currently only supports YouTube
+    storyboard_enable = true,
 }
 
 read_options(thumbnailer_options, SCRIPT_NAME)

--- a/src/thumbnailer_server.lua
+++ b/src/thumbnailer_server.lua
@@ -124,6 +124,28 @@ function check_output(ret, output_path, is_mpv)
     return success
 end
 
+-- split cols x N atlas in BGRA format into many thumbnail files
+function split_atlas(atlas_path, cols, thumbnail_size, template, offset)
+    local atlas = io.open(atlas_path, "rb")
+    local atlas_filesize = atlas:seek("end")
+    local atlas_pictures = math.floor(atlas_filesize / (4 * thumbnail_size.w * thumbnail_size.h))
+    for pic = 0, atlas_pictures-1 do
+        local idx = offset + pic
+        local x_start = (pic % cols) * thumbnail_size.w
+        local y_start = math.floor(pic / cols) * thumbnail_size.h
+        local thumb_file = io.open(template:format(idx), "wb")
+        local stride = 4 * thumbnail_size.w * math.min(cols, atlas_pictures)
+        for line = 0, thumbnail_size.h - 1 do
+            atlas:seek("set", 4 * x_start + (y_start + line) * stride)
+            local data = atlas:read(thumbnail_size.w * 4)
+            if data ~= nil then
+                thumb_file:write(data)
+            end
+        end
+        thumb_file:close()
+    end
+    atlas:close()
+end
 
 function do_worker_job(state_json_string, frames_json_string)
     msg.debug("Handling given job")
@@ -151,7 +173,7 @@ function do_worker_job(state_json_string, frames_json_string)
     local file_duration = mp.get_property_native("duration")
     local file_path = thumb_state.worker_input_path
 
-    if thumb_state.is_remote then
+    if thumb_state.is_remote and thumb_state.storyboard_url == nil then
         if (thumbnail_func == create_thumbnail_ffmpeg) then
             msg.warn("Thumbnailing remote path, falling back on mpv.")
         end
@@ -189,8 +211,24 @@ function do_worker_job(state_json_string, frames_json_string)
         end
 
         if need_thumbnail_generation then
-            local ret = thumbnail_func(file_path, timestamp, thumb_state.thumbnail_size, thumbnail_path, thumb_state.worker_extra)
-            local success = check_output(ret, thumbnail_path, thumbnail_func == create_thumbnail_mpv)
+            local success
+            if thumb_state.storyboard_url ~= nil then
+                -- get atlas and then split it into thumbnails
+                local rows = 5
+                local cols = 5
+                local atlas_idx = math.floor(thumb_idx/(cols*rows))
+                local atlas_path = thumb_state.thumbnail_template:format(atlas_idx) .. ".atlas"
+                local url = thumb_state.storyboard_url[atlas_idx+1].url
+                local ret = thumbnail_func(url, 0, thumb_state.thumbnail_size, atlas_path, { no_scale=true })
+                success = check_output(ret, atlas_path, thumbnail_func == create_thumbnail_mpv)
+                if success then
+                    split_atlas(atlas_path, cols, thumb_state.thumbnail_size, thumb_state.thumbnail_template, atlas_idx * cols * rows)
+                    os.remove(atlas_path)
+                end
+            else
+                local ret = thumbnail_func(file_path, timestamp, thumb_state.thumbnail_size, thumbnail_path, thumb_state.worker_extra)
+                success = check_output(ret, thumbnail_path, thumbnail_func == create_thumbnail_mpv)
+            end
 
             if success == nil then
                 -- Killed by us, changing files, ignore

--- a/src/thumbnailer_server.lua
+++ b/src/thumbnailer_server.lua
@@ -55,7 +55,8 @@ function create_thumbnail_mpv(file_path, timestamp, size, output_path, options)
         -- Optionally disable subtitles
         (thumbnailer_options.mpv_no_sub and "--no-sub" or nil),
 
-        ("--vf=scale=%d:%d"):format(size.w, size.h),
+        (options.no_scale == nil and ("--vf=scale=%d:%d"):format(size.w, size.h) or nil),
+
         "--vf-add=format=bgra",
         "--of=rawvideo",
         "--ovc=rawvideo",
@@ -65,8 +66,10 @@ function create_thumbnail_mpv(file_path, timestamp, size, output_path, options)
 end
 
 
-function create_thumbnail_ffmpeg(file_path, timestamp, size, output_path)
-    local ffmpeg_command = {
+function create_thumbnail_ffmpeg(file_path, timestamp, size, output_path, options)
+    options = options or {}
+
+    local ffmpeg_command = skip_nil({
         "ffmpeg",
         "-loglevel", "quiet",
         "-noaccurate_seek",
@@ -76,13 +79,13 @@ function create_thumbnail_ffmpeg(file_path, timestamp, size, output_path)
         "-frames:v", "1",
         "-an",
 
-        "-vf", ("scale=%d:%d"):format(size.w, size.h),
+        (options.no_scale == nil and "-vf" or nil), (options.no_scale == nil and ("scale=%d:%d"):format(size.w, size.h) or nil),
         "-c:v", "rawvideo",
         "-pix_fmt", "bgra",
         "-f", "rawvideo",
 
         "-y", output_path
-    }
+    })
     return utils.subprocess({args=ffmpeg_command})
 end
 

--- a/src/thumbnailer_shared.lua
+++ b/src/thumbnailer_shared.lua
@@ -313,17 +313,19 @@ function Thumbnailer:register_client()
     end)
 
     -- Notify workers to generate thumbnails when video loads/changes
-    -- This will be executed after the on_video_change (because it's registered after it)
-    mp.observe_property("video-dec-params", "native", function()
-        local duration = mp.get_property_native("duration")
-        local max_duration = thumbnailer_options.autogenerate_max_duration
+    mp.observe_property("video-dec-params", "native", function(name, params)
+        Thumbnailer:on_video_change(params)
+        self:check_storyboard_async(function()
+            local duration = mp.get_property_native("duration")
+            local max_duration = thumbnailer_options.autogenerate_max_duration
 
-        if duration ~= nil and self.state.available and thumbnailer_options.autogenerate then
-            -- Notify if autogenerate is on and video is not too long
-            if duration < max_duration or max_duration == 0 then
-                self:start_worker_jobs()
+            if duration ~= nil and self.state.available and thumbnailer_options.autogenerate then
+                -- Notify if autogenerate is on and video is not too long
+                if duration < max_duration or max_duration == 0 then
+                    self:start_worker_jobs()
+                end
             end
-        end
+        end)
     end)
 
     local thumb_script_key = not thumbnailer_options.disable_keybinds and "T" or nil
@@ -468,4 +470,3 @@ function Thumbnailer:start_worker_jobs()
 end
 
 mp.register_event("start-file", function() Thumbnailer:on_start_file() end)
-mp.observe_property("video-dec-params", "native", function(name, params) Thumbnailer:on_video_change(params) end)


### PR DESCRIPTION
Calls yt-dlp to get URLs with thumbnail atlases("storyboard") if it's a network stream (format "sb0").
Then downloads these atlases and splits them into thumbnails. This allows for much faster thumbnail generation (a few seconds).
Currently yt-dlp only supports storyboards for youtube.
This PR assumes 5x5 atlases (currently yt-dlp doesn't expose atlas dimensions, I'll open a PR to yt-dlp later)
