### PR TITLE
Storyboard fixes

### DIFF
--- a/src/options.lua
+++ b/src/options.lua
@@ -123,6 +123,8 @@ local thumbnailer_options = {
     storyboard_enable = true,
     -- Max thumbnails for storyboards. It only skips processing some of the downloaded thumbnails and doesn't make it much faster
     storyboard_max_thumbnail_count = 800,
+    -- Most storyboard thumbnails are 160x90. Enabling this allows upscaling them up to thumbnail_height
+    storyboard_upscale = false,
 }
 
 read_options(thumbnailer_options, SCRIPT_NAME)

--- a/src/options.lua
+++ b/src/options.lua
@@ -121,6 +121,8 @@ local thumbnailer_options = {
 
     -- Enable storyboards (requires yt-dlp in PATH). Currently only supports YouTube
     storyboard_enable = true,
+    -- Max thumbnails for storyboards. It only skips processing some of the downloaded thumbnails and doesn't make it much faster
+    storyboard_max_thumbnail_count = 800,
 }
 
 read_options(thumbnailer_options, SCRIPT_NAME)

--- a/src/options.lua
+++ b/src/options.lua
@@ -1,6 +1,6 @@
 local SCRIPT_NAME = "mpv_thumbnail_script"
 
-local default_cache_base = ON_WINDOWS and os.getenv("TEMP") or "/tmp/"
+local default_cache_base = ON_WINDOWS and os.getenv("TEMP") or (os.getenv("XDG_CACHE_HOME") or "/tmp/")
 
 local thumbnailer_options = {
     -- The thumbnail directory

--- a/src/thumbnailer_server.lua
+++ b/src/thumbnailer_server.lua
@@ -173,7 +173,7 @@ function do_worker_job(state_json_string, frames_json_string)
     local file_duration = mp.get_property_native("duration")
     local file_path = thumb_state.worker_input_path
 
-    if thumb_state.is_remote and thumb_state.storyboard_url == nil then
+    if thumb_state.is_remote and thumb_state.storyboard == nil then
         if (thumbnail_func == create_thumbnail_ffmpeg) then
             msg.warn("Thumbnailing remote path, falling back on mpv.")
         end
@@ -212,13 +212,16 @@ function do_worker_job(state_json_string, frames_json_string)
 
         if need_thumbnail_generation then
             local success
-            if thumb_state.storyboard_url ~= nil then
+            if thumb_state.storyboard ~= nil then
                 -- get atlas and then split it into thumbnails
-                local rows = 5
-                local cols = 5
+                local rows = thumb_state.storyboard.rows
+                local cols = thumb_state.storyboard.cols
                 local atlas_idx = math.floor(thumb_idx/(cols*rows))
                 local atlas_path = thumb_state.thumbnail_template:format(atlas_idx) .. ".atlas"
-                local url = thumb_state.storyboard_url[atlas_idx+1].url
+                local url = thumb_state.storyboard.fragments[atlas_idx+1].url
+                if url == nil then
+                    url = thumb_state.storyboard.fragment_base_url .. "/" .. thumb_state.storyboard.fragments[atlas_idx+1].path
+                end
                 local ret = thumbnail_func(url, 0, thumb_state.thumbnail_size, atlas_path, { no_scale=true })
                 success = check_output(ret, atlas_path, thumbnail_func == create_thumbnail_mpv)
                 if success then

--- a/src/thumbnailer_shared.lua
+++ b/src/thumbnailer_shared.lua
@@ -108,7 +108,7 @@ function Thumbnailer:check_storyboard_async(callback)
                     self.state.storyboard.fragment_base_url = sb.fragment_base_url
                     self.state.storyboard.rows = sb.rows or 5
                     self.state.storyboard.cols = sb.columns or 5
-                    self.state.thumbnail_size = {w=sb.width, h=sb.height}
+
                     if sb.fps then
                         self.state.thumbnail_count = math.floor(sb.fps * sb.duration + 0.5) -- round
                         -- hack: youtube always adds 1 black frame at the end...
@@ -121,6 +121,16 @@ function Thumbnailer:check_storyboard_async(callback)
                         self.state.thumbnail_delta = sb.fragments[1].duration / (self.state.storyboard.rows*self.state.storyboard.cols)
                         self.state.thumbnail_count = math.floor(sb.duration / self.state.thumbnail_delta)
                     end
+
+                    -- Storyboard upscaling factor
+                    local scale = 1
+                    if thumbnailer_options.storyboard_upscale then
+                        -- BUG: sometimes mpv crashes when asked for non-integer scaling and BGRA format (something related to zimg?)
+                        -- use integer scaling for now
+                        scale = math.max(1, math.floor(thumbnailer_options.thumbnail_height / sb.height))
+                    end
+                    self.state.thumbnail_size = {w=sb.width*scale, h=sb.height*scale}
+                    self.state.storyboard.scale = scale
 
                     local divisor = 1 -- only save every n-th thumbnail
                     if thumbnailer_options.storyboard_max_thumbnail_count then

--- a/src/thumbnailer_shared.lua
+++ b/src/thumbnailer_shared.lua
@@ -63,7 +63,7 @@ function Thumbnailer:on_thumb_ready(index)
 end
 
 function Thumbnailer:on_thumb_progress(index)
-    self.state.thumbnails[index] = self.state.thumbnails[index] == 1
+    self.state.thumbnails[index] = (self.state.thumbnails[index] == 1) and 1 or 0
 end
 
 function Thumbnailer:on_start_file()

--- a/src/thumbnailer_shared.lua
+++ b/src/thumbnailer_shared.lua
@@ -63,7 +63,7 @@ function Thumbnailer:on_thumb_ready(index)
 end
 
 function Thumbnailer:on_thumb_progress(index)
-    self.state.thumbnails[index] = math.max(self.state.thumbnails[index], 0)
+    self.state.thumbnails[index] = self.state.thumbnails[index] == 1
 end
 
 function Thumbnailer:on_start_file()

--- a/src/thumbnailer_shared.lua
+++ b/src/thumbnailer_shared.lua
@@ -100,12 +100,23 @@ function Thumbnailer:check_storyboard_async(callback)
                     self.state.thumbnail_size = {w=sb.width, h=sb.height}
                     if sb.fps then
                         self.state.thumbnail_count = math.floor(sb.fps * sb.duration)
-                        self.state.thumbnail_delta = sb.duration / self.state.thumbnail_count
                     else
                         -- estimate the count of thumbnails
                         self.state.thumbnail_delta = sb.fragments[1].duration / (self.state.storyboard.rows*self.state.storyboard.cols) -- first atlas is always full
                         self.state.thumbnail_count = math.floor(sb.duration / self.state.thumbnail_delta)
                     end
+
+                    local divisor = 1 -- only save every n-th thumbnail
+                    if thumbnailer_options.storyboard_max_thumbnail_count then
+                        while self.state.thumbnail_count / divisor > thumbnailer_options.storyboard_max_thumbnail_count do
+                            divisor = divisor + 1
+                        end
+                    end
+                    self.state.storyboard.divisor = divisor
+                    self.state.thumbnail_count = math.floor(self.state.thumbnail_count / divisor)
+                    self.state.thumbnail_delta = sb.duration / self.state.thumbnail_count
+
+
                     -- Prefill individual thumbnail states
                     self.state.thumbnails = {}
                     for i = 1, self.state.thumbnail_count do

--- a/src/thumbnailer_shared.lua
+++ b/src/thumbnailer_shared.lua
@@ -84,7 +84,7 @@ end
 function Thumbnailer:check_storyboard_async(callback)
     if thumbnailer_options.storyboard_enable and self.state.is_remote then
         msg.info("Trying to get storyboard info...")
-        local sb_cmd = {"yt-dlp", "--format", "sb0", "--dump-json",
+        local sb_cmd = {"yt-dlp", "--format", "sb0", "--dump-json", "--no-playlist",
                         "--extractor-args", "youtube:skip=hls,dash,translated_subs", -- yt speedup
                         "--", mp.get_property_native("path")}
 


### PR DESCRIPTION
Hopefully fixes issues mentioned in #23 and #24, as well as adds support for twitch VoDs storyboards https://github.com/yt-dlp/yt-dlp/pull/4342 (newest yt-dlp version).

Limit thumbnails count for storyboards (separate option since it doesn't make thumbnail generation any faster)
Use XDG cache dir on unix for cache