### PR TITLE
Less precise seek

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ max_delta=90
 # Default to no, see https://mpv.io/manual/master/#options-hwdec for the values
 mpv_hwdec=no
 
+# Parameter that mpv should use for seeking
+# yes extracts the exact frame
+# no extracts the closest keyframe, faster but less precise
+# Default to yes
+mpv_hr_seek=yes
+
 
 # Remote options
 

--- a/src/options.lua
+++ b/src/options.lua
@@ -35,6 +35,8 @@ local thumbnailer_options = {
     mpv_profile = "",
     -- Hardware decoding
     mpv_hwdec = "no",
+    -- High precision seek
+    mpv_hr_seek = "yes",
     -- Output debug logs to <thumbnail_path>.log, ala <cache_directory>/<video_filename>/000000.bgra.log
     -- The logs are removed after successful encodes, unless you set mpv_keep_logs below
     mpv_logs = true,

--- a/src/thumbnailer_server.lua
+++ b/src/thumbnailer_server.lua
@@ -50,7 +50,7 @@ function create_thumbnail_mpv(file_path, timestamp, size, output_path, options)
 
         "--start=" .. tostring(timestamp),
         "--frames=1",
-        "--hr-seek=yes",
+        "--hr-seek=" .. thumbnailer_options.mpv_hr_seek,
         "--no-audio",
         -- Optionally disable subtitles
         (thumbnailer_options.mpv_no_sub and "--no-sub" or nil),


### PR DESCRIPTION
Add the option to pass `--hr-seek=no` to mpv, which is less precise (closest keyframe) but can speed up thumbnail generation.