### PR TITLE
Homebrew path fix on MacOS

### DIFF
--- a/lib/helpers.lua
+++ b/lib/helpers.lua
@@ -3,8 +3,12 @@ local msg = require 'mp.msg'
 local opt = require 'mp.options'
 local utils = require 'mp.utils'
 
--- Determine platform --
+-- Determine if the platform is Windows --
 ON_WINDOWS = (package.config:sub(1,1) ~= '/')
+
+-- Determine if the platform is MacOS --
+local uname = io.popen("uname -s"):read("*l")
+ON_MAC = not ON_WINDOWS and (uname == "Mac" or uname == "Darwin")
 
 -- Some helper functions needed to parse the options --
 function isempty(v) return (v == false) or (v == nil) or (v == "") or (v == 0) or (type(v) == "table" and next(v) == nil) end

--- a/src/thumbnailer_server.lua
+++ b/src/thumbnailer_server.lua
@@ -26,8 +26,10 @@ function create_thumbnail_mpv(file_path, timestamp, size, output_path, options)
 
     local log_arg = "--log-file=" .. output_path .. ".log"
 
+    local mpv_path = ON_MAC and "/opt/homebrew/bin/mpv" or "mpv"
+
     local mpv_command = skip_nil({
-        "mpv",
+        mpv_path,
         -- Hide console output
         "--msg-level=all=no",
 
@@ -71,8 +73,10 @@ end
 function create_thumbnail_ffmpeg(file_path, timestamp, size, output_path, options)
     options = options or {}
 
+    local ffmpeg_path = ON_MAC and "/opt/homebrew/bin/ffmpeg" or "ffmpeg"
+
     local ffmpeg_command = {
-        "ffmpeg",
+        ffmpeg_path,
         "-loglevel", "quiet",
         "-noaccurate_seek",
         "-ss", format_time(timestamp, ":"),


### PR DESCRIPTION
Fix for issue #29 
Works on MacOS 16.2 (MacBook Pro with M1).
mpv installed with brew. `PATH` contains homebrew path. Workaround in the issue.